### PR TITLE
fix url of kernel version if version is not in the 4.x

### DIFF
--- a/deploy_toolchain_x86_64-ace-linux-gnu
+++ b/deploy_toolchain_x86_64-ace-linux-gnu
@@ -28,6 +28,7 @@ readonly BINUTILS_VERSION=2.26
 readonly GDC_COMMIT=55bb5b0e5da16522aeaa9ec62dfc5a23fe2be44c
 readonly GLIBC_VERSION=2.22
 readonly KERNEL_VERSION=4.4.1
+readonly KERNEL_MAJOR=$(echo $KERNEL_VERSION | cut -d. -f1)
 
 readonly GCC_LANGS="c,c++,d"
 
@@ -108,7 +109,7 @@ function binutils_build
 
 function sysheaders_download
 {
-  atomic_wget "https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-$KERNEL_VERSION.tar.xz" "$ARCHIVES/linux-$KERNEL_VERSION.tar.xz"
+  atomic_wget "https://cdn.kernel.org/pub/linux/kernel/v$KERNEL_MAJOR.x/linux-$KERNEL_VERSION.tar.xz" "$ARCHIVES/linux-$KERNEL_VERSION.tar.xz"
   atomic_wget "http://ftp.gnu.org/gnu/glibc/glibc-$GLIBC_VERSION.tar.xz" "$ARCHIVES/glibc-$GLIBC_VERSION.tar.xz"
 }
 


### PR DESCRIPTION
fix #3, create url with kernel major instead of 4.x value